### PR TITLE
Update KismetLogger to v5

### DIFF
--- a/KismetLogger/KismetLogger.cpp
+++ b/KismetLogger/KismetLogger.cpp
@@ -15,17 +15,16 @@
 #define _CRT_SECURE_NO_WARNINGS
 #pragma comment(lib, "detours.lib") //Library needed for Hooking part.
 
-ME3TweaksASILogger logger("Kismet Logger v4", "KismetLog.txt");
+ME3TweaksASILogger logger("Kismet Logger v5", "KismetLog.txt");
 
 void __fastcall HookedPE(UObject *pObject, void *edx, UFunction *pFunction, void *pParms, void *pResult)
 {
 	char *szName = pFunction->GetFullName();
 	if (isPartOf(szName, "Function Engine.SequenceOp.Activated")) {
 		USequenceOp* op = (USequenceOp*)pObject;
-		char* fullname = op->GetFullName();
-		char* mapname = op->GetContainingMapName();
-		int instanceIndex = op->Name.GetIndex();
-		logger.writeToLog(string_format("(%s) %s_%d\n", mapname, fullname, instanceIndex), true);
+		const char* fullInstancedPath = op->GetFullPath();
+		const char* className = op->Class->Name.GetName();
+		logger.writeToLog(string_format("%s %s\n", className, fullInstancedPath), true);
 	}
 	ProcessEvent(pObject, pFunction, pParms, pResult);
 }

--- a/ME3SDK/SDK_HEADERS/Core_classes.h
+++ b/ME3SDK/SDK_HEADERS/Core_classes.h
@@ -211,11 +211,13 @@ private:
 public:
 	static TArray< UObject* >* GObjObjects(); 
 
-	char* GetName(); 
+	char* GetName();
+	char* GetInstancedName();
 	char* GetNameCPP(); 
 	char* GetFullName();
 	char* GetFullNameNoClass();
 	char* GetFullName2();
+	char* GetFullPath();
 
 	template< class T > static T* FindObject ( char* ObjectFullName ); 
 	static UClass* FindClass ( char* ClassFullName ); 

--- a/ME3SDK/SDK_HEADERS/Core_functions.h
+++ b/ME3SDK/SDK_HEADERS/Core_functions.h
@@ -36,6 +36,22 @@ char* UObject::GetName()
 	return cOutBuffer; 
 } 
 
+char* UObject::GetInstancedName()
+{
+	static char cOutBuffer[256];
+
+	if (this->Name.NameIndex > 0)
+	{
+		sprintf_s(cOutBuffer, "%s_%d", this->Name.GetName(), this->Name.NameIndex - 1);
+	}
+	else
+	{
+		sprintf_s(cOutBuffer, "%s", this->Name.GetName());
+	}
+
+	return cOutBuffer;
+}
+
 char* UObject::GetNameCPP() 
 { 
 	static char cOutBuffer[ 256 ]; 
@@ -157,6 +173,25 @@ char* UObject::GetFullName2()
 	}
 
 	return "(null)";
+}
+
+void GetFullPathInternal(UObject* object, char* str)
+{
+	if (object->Outer)
+	{
+		GetFullPathInternal(object->Outer, str);
+		strcat_s(str, 512, ".");
+	}
+	strcat_s(str, 512, object->GetInstancedName());
+}
+
+char* UObject::GetFullPath()
+{
+	static char cOutBuffer[512];
+	cOutBuffer[0] = '\0';
+	GetFullPathInternal(this, cOutBuffer);
+
+	return cOutBuffer;
 }
 
 template< class T > T* UObject::FindObject ( char* ObjectFullName ) 


### PR DESCRIPTION
KismetLogger now uses full instanced path, with implementation ported from LE1 SDK. All instances of KismetLogger need to be updated to use the new format.